### PR TITLE
fix waveform generation when clock is not 125 MHz

### DIFF
--- a/generation/generation.py
+++ b/generation/generation.py
@@ -13,8 +13,6 @@ from array import array
 from math import floor
 from uctypes import addressof
 
-system_clock = freq()  # clock frequency of the pico
-
 DMA_BASE = 0x50000000
 CH0_READ_ADDR = DMA_BASE + 0x000
 CH0_WRITE_ADDR = DMA_BASE + 0x004
@@ -164,7 +162,7 @@ def start_waveform_generation(buffer, waveform_type, parameters, max_sample_coun
         ParamNames.FREQUENCY, WaveformParams.FREQUENCY.min
     )
     # Determine clock division to accommodate the waveform frequency within the buffer capacity
-    clock_division_factor = system_clock / (target_frequency * max_sample_count)
+    clock_division_factor = freq() / (target_frequency * max_sample_count)
 
     if clock_division_factor < 1.0:
         # If the clock cannot be sped up, increase the number of waveform cycles in the buffer
@@ -238,7 +236,7 @@ class WaveformGenerator:
         self.buffer = {}
         self.buffer[0] = bytearray(self.maxnsamp)
         self.buffer[1] = bytearray(self.maxnsamp)
-        self.state_machine = StateMachine(0, stream, freq=system_clock, out_base=Pin(0))
+        self.state_machine = StateMachine(0, stream, out_base=Pin(0))
         self.state_machine.active(1)
 
     def _switch_buffer(self):


### PR DESCRIPTION
`system_clock = freq()` gets evaluated at import time, but the new frequency is set after that, making this value outdated. Load it dynamically when generating the waveform. The default for `StateMachine` is to run at the system clock so omitting the parameter there has the desired behaviour.

To reproduce:
Run the pico at a frequency different than the 125 MHz default, e.g. I chose 200MHz (`generation/constants.py` defaults to a more aggressive 250MHz)

150 kHz sine wave when running at 200MHz was actually measured at 240 kHz.

After the change the generated signal is accurate.